### PR TITLE
use absolutePosition()

### DIFF
--- a/marble.lua
+++ b/marble.lua
@@ -58,12 +58,12 @@ dragOtherToScroll = hs.eventtap.new({ hs.eventtap.event.types.otherMouseDragged 
         then 
             -- print("scroll");
             deferred = false
-            oldmousepos = hs.mouse.getAbsolutePosition()    
+            oldmousepos = hs.mouse.absolutePosition()    
             local dx = e:getProperty(hs.eventtap.event.properties['mouseEventDeltaX'])
             local dy = e:getProperty(hs.eventtap.event.properties['mouseEventDeltaY'])
             local scroll = hs.eventtap.event.newScrollEvent({dx * scrollmult, dy * scrollmult},{},'pixel')
             -- put the mouse back
-            hs.mouse.setAbsolutePosition(oldmousepos)
+            hs.mouse.absolutePosition(oldmousepos)
             return true, {scroll}
         else 
             return false, {}


### PR DESCRIPTION
`getAbsolutePosition()` and `setAbsolutePosition()` are deprecated. This change uses `absolutePosition()` instead, ensuring that the scroll wheel remains functional.

Resolves #1